### PR TITLE
fix wrong match

### DIFF
--- a/wp-useragent-detect-webbrowser.php
+++ b/wp-useragent-detect-webbrowser.php
@@ -1105,7 +1105,7 @@ function wpua_detect_webbrowser()
 		$code = 'opera-2';
 	}
 	elseif (preg_match('/Opera/i', $useragent)
-		|| preg_match('/OPR/i', $useragent))
+		|| preg_match('/OPR\/(\S+)/', $useragent))
 	{
 		$link = 'http://www.opera.com/';
 		$title = 'Opera';


### PR DESCRIPTION
fix wrong match
such as `Mozilla/5.0 (Linux; Android 8.0.0; MIX 2 Build/OPR1.170623.027; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/71.0.3578.99 Mobile Safari/537.36` will be matched as opera, but it's chrome

this fix it